### PR TITLE
Updated GithubPRChecker to use the search API instead of Events

### DIFF
--- a/src/AppBundle/Controller/DefaultController.php
+++ b/src/AppBundle/Controller/DefaultController.php
@@ -35,8 +35,12 @@ class DefaultController extends Controller
         if (!$pullrequests) {
             $token = $this->getDoctrine()->getRepository('AppBundle:Credentials')->getGithubToken($user->getId());
             $github = new GithubPRChecker($token);
-            $pullrequests = $github->getUserPullRequests($user->getUsername());
-            $cache->save($key, $pullrequests);
+            $search = $github->getUserPullRequests($user->getUsername());
+
+            if ($search) {
+                $pullrequests = $search['pullrequests'];
+                $cache->save($key, $pullrequests);
+            }
         }
 
 


### PR DESCRIPTION
Now the verification uses the Search API, for more accuracy and higher limits.

The Events API has a limitation of only 300 events maximum, so the verification was not working well for users with high activity on Github.

Now it works :dancers: :dancer: 
