### PR TITLE
Inclusive of Alofi, Niue (+ Pacific Coast) with -11:00

### DIFF
--- a/src/AppBundle/Service/GithubPRChecker.php
+++ b/src/AppBundle/Service/GithubPRChecker.php
@@ -56,7 +56,7 @@ class GithubPRChecker
      */
     public function getUserPullRequests($username, $lazy = false)
     {
-        $url = self::$API_BASE . "/search/issues?q=author:$username+type:pr+created:2015-10-01..2015-10-31";
+        $url = self::$API_BASE . "/search/issues?q=author:$username+type:pr+created:2015-10-01..2015-10-31T23:59:59-11:00";
 
         $response = $this->authenticatedRequest($url);
         $pullrequests = [];


### PR DESCRIPTION
Inclusive of the last possible time zone commits on October 31, 2015, coming in at -11 UTC.
http://www.timeanddate.com/worldclock/niue/alofi
