### PR TITLE
Added overflow-wrap for the project title

### DIFF
--- a/web/assets/css/custom.css
+++ b/web/assets/css/custom.css
@@ -38,6 +38,7 @@ div.verification-result strong {
 }
 
 div.pullrequest .project {
+    overflow-wrap: break-word;
     background-color: #0088CC;
     padding: 4px 6px;
     color: #F5F5F5;


### PR DESCRIPTION
Wrap the title for the project (div.pullrequest .project) when the screen width is too small with overflow-wrap: break-word.
